### PR TITLE
feat(flow-viz-prompt): add Cartoon & Sketch visual style

### DIFF
--- a/flow-viz-prompt/SKILL.md
+++ b/flow-viz-prompt/SKILL.md
@@ -1,11 +1,15 @@
 ---
 name: flow-viz-prompt
-description: Use when user wants to generate an image-generation prompt for a pipeline, workflow, or codebase architecture diagram. Triggers on: "flowchart prompt", "diagram prompt", "figure prompt", "visualization prompt", and Chinese: "流程图提示词", "架构图提示词", "画图提示词", "pipeline可视化提示词", "给我一个流程图的prompt". Do NOT trigger on requests to just draw or show a diagram without "prompt" — e.g., "draw graph", "生成流程图" alone should NOT trigger this skill.
+description: Use when user wants to generate an image-generation prompt for a pipeline, workflow, or codebase architecture diagram. Supports NotebookLM (clean/professional) and Cartoon & Sketch (hand-drawn/playful) styles. Triggers on: "flowchart prompt", "diagram prompt", "figure prompt", "visualization prompt", "cartoon flowchart", "sketch diagram", and Chinese: "流程图提示词", "架构图提示词", "画图提示词", "pipeline可视化提示词", "给我一个流程图的prompt", "卡通流程图", "手绘架构图". Do NOT trigger on requests to just draw or show a diagram without "prompt" — e.g., "draw graph", "生成流程图" alone should NOT trigger this skill.
 ---
 
 # Flow Viz Prompt
 
-Converts any pipeline or workflow into a professional image-generation prompt, ready to paste into Gemini or any image-generation model. Fixed visual style: **NotebookLM Style** (clean digital whiteboard aesthetic).
+Converts any pipeline or workflow into a professional image-generation prompt, ready to paste into Gemini or any image-generation model.
+
+Supports two visual styles:
+- **NotebookLM Style** (default): Clean digital whiteboard aesthetic, professional and modern
+- **Cartoon & Sketch Style**: Hand-drawn, playful illustration aesthetic inspired by [angie.temaly.com](https://angie.temaly.com/) — ideal for blog posts, social media, and making technical content more approachable
 
 Supports two granularity levels:
 - **Reporting granularity** (default): Suitable for PPT/tech presentations — nodes are abstract step names, no code details
@@ -25,7 +29,20 @@ A complete image-generation prompt in the confirmed output language, ready to pa
 
 ---
 
-## Step 0: Granularity Detection (automatic, no prompting)
+## Step 0: Style & Granularity Detection (automatic, no prompting)
+
+### Style Detection
+
+Infer visual style from the user's trigger phrase:
+
+| Style | Trigger keywords (any match) |
+|-------|------------------------------|
+| **Cartoon & Sketch** | "cartoon", "sketch", "hand-drawn", "doodle", "playful", "fun", "cute", "illustrated", "卡通", "手绘", "涂鸦", "可爱风", "sketch style" |
+| **NotebookLM** | All other cases (default) |
+
+Announce the detected style: `[Style: NotebookLM]` or `[Style: Cartoon & Sketch]`.
+
+### Granularity Detection
 
 Infer granularity from the user's trigger phrase:
 
@@ -160,7 +177,78 @@ Module boundaries:
 
 ---
 
+## Cartoon & Sketch Visual Style Spec
+
+Inspired by [angie.temaly.com](https://angie.temaly.com/) — a playful, hand-drawn illustration aesthetic that makes technical diagrams feel approachable and engaging.
+
+```
+Visual aesthetic: hand-drawn, playful cartoon/sketch illustration style,
+  as if drawn on a notebook page with colored markers and pens
+Background: off-white paper texture with subtle grid or dot pattern (like a notebook page)
+Node shape: hand-drawn rounded rectangles with slightly wobbly/imperfect edges,
+  as if sketched by hand with a marker
+Lines: hand-drawn style arrows with slight wobble, playful curved connectors
+  instead of straight lines, arrow tips are hand-drawn triangles
+Font: handwriting-style or casual rounded sans-serif (e.g., Comic Neue, Caveat, or
+  Patrick Hand feel), slightly tilted text for playfulness
+
+Color scheme (by layer):
+  - Input layer: pastel yellow with hand-drawn border
+  - Core processing nodes: pastel blue/lavender with doodle-style icons
+  - Sub-regions / parallel paths: pastel green (primary) / pastel pink (secondary)
+  - External references / databases: small hand-drawn icons (cloud doodle, folder sketch)
+  - Output layer: pastel coral/orange with a small star or sparkle doodle
+  - Containers: hand-drawn dashed borders, slightly irregular
+
+Decorative elements:
+  - Small doodle icons next to node labels (e.g., gear ⚙️ for processing,
+    lightbulb 💡 for input, rocket 🚀 for output)
+  - Occasional small stars, dots, or squiggles as decoration (not excessive)
+  - Subtle drop shadows that look hand-drawn (cross-hatching style)
+
+Layout direction: left-to-right (default) or top-to-bottom (when content is dense)
+All text: [confirmed language]
+```
+
+### Code granularity — additional Cartoon & Sketch style rules
+
+Applied on top of the Cartoon & Sketch base spec above:
+
+```
+Node internal structure (code granularity only):
+  - Each node looks like a hand-drawn sticky note or index card
+  - Top zone (title): step name in bold handwriting style
+  - Bottom zone (code annotation): file path + function name in a
+    smaller handwriting-monospace hybrid font, inside a small
+    hand-drawn code block (like a torn piece of paper)
+  - Code annotation format: 📝 path/to/file.rs → func_name()
+
+Call relationship arrows (code granularity only):
+  - Direct function call: hand-drawn solid arrow with slight curve
+  - Cross-process / CLI / tool call: hand-drawn dashed arrow with
+    a small lightning bolt or gear icon, labeled with call method
+  - Arrow labels use casual handwriting font
+
+Module boundaries:
+  - Different languages / runtimes use different pastel background tints
+    with hand-drawn borders:
+    - TypeScript module: pastel blue sticky note
+    - Rust module: pastel orange sticky note
+    - Python module: pastel green sticky note
+    - Shell / CLI: light gray torn paper
+  - Boundaries have wobbly hand-drawn borders with a small doodle
+    language icon at the top corner
+```
+
+---
+
 ## Prompt Generation Templates
+
+### Style Selection
+
+When generating prompts, select the visual style section matching the detected style:
+- **NotebookLM**: Use Template A/B with NotebookLM visual style requirements
+- **Cartoon & Sketch**: Use Template C/D with Cartoon & Sketch visual style requirements
 
 ### Template A: Reporting Granularity (default)
 
@@ -286,6 +374,120 @@ Core steps:
 Call relationships: `App` → solid arrow → `AgentControl`; `AgentControl` → dashed arrow (HTTP) → OpenAI API; `AgentControl` → solid arrow → `apply_patch`
 Output layer: Applied code patches | Shell command output
 
+### Template C: Cartoon & Sketch — Reporting Granularity
+
+Generate the prompt using the structure below, replacing `[...]` with the user-confirmed content:
+
+```
+Please generate a playful, hand-drawn style flowchart illustration, as if sketched on a notebook page with colored markers.
+
+**Topic**: "[topic name]"
+
+### Visual Style Requirements (Cartoon & Sketch Style)
+
+- Visual aesthetic: hand-drawn cartoon/sketch illustration, playful and approachable,
+  as if drawn on notebook paper with colored markers and pens
+- Element style: hand-drawn rounded rectangles with slightly wobbly/imperfect edges,
+  playful curved arrow connectors with hand-drawn triangle tips
+- Background: off-white paper texture with subtle grid or dot pattern
+- Color scheme: input layer in pastel yellow; core processing area in pastel blue/lavender;
+  [if sub-paths: primary path pastel green, secondary path pastel pink]; output layer pastel coral/orange
+- Typography: handwriting-style or casual rounded sans-serif font, slightly playful
+- Decorative elements: small doodle icons next to labels (gear for processing, lightbulb for input,
+  rocket for output), occasional small stars or squiggles as decoration (not excessive)
+- Containers: hand-drawn dashed borders with slightly irregular edges
+
+### Flowchart Structure and Content ([layout direction] layout, all text in [confirmed language])
+
+**[Column 1: Input Layer]**
+[One pastel-yellow hand-drawn node per input source, with a small lightbulb doodle,
+listing key sub-items inside in handwriting font]
+[All input nodes converge via curvy hand-drawn arrows to a small doodle merge point,
+then a single curvy arrow continues right]
+
+**[Column 2: Core Processing Area (main body, largest area)]**
+[If large container: hand-drawn rounded container with wobbly border labeled "[Step name]",
+containing sub-regions]
+[Sub-regions wrapped in hand-drawn dashed borders with region labels]
+[Each sub-node: bold handwriting label + indented list items, with small gear/tool doodles]
+[External reference nodes: side-attached with small hand-drawn cloud/folder icons,
+curvy arrow pointing into corresponding node, labeled "[label]"]
+
+**[Last Column: Output Layer]**
+Curvy hand-drawn arrow from core area pointing to a pastel coral/orange output node
+with a small rocket or star doodle, labeled: "[output name]"
+Inside the node, organized by dimension:
+- [Dimension 1]: [value 1] | [value 2] | ...
+- [Dimension 2]: [value A] | [value B] | ...
+
+### Final Check
+Ensure all text is clear and in [confirmed language]; the overall feel is playful and hand-drawn
+but still technically accurate; doodle decorations enhance readability without cluttering;
+flow direction is clear; suitable for blog posts, social media, or approachable presentations.
+```
+
+### Template D: Cartoon & Sketch — Code Granularity
+
+```
+Please generate a playful, hand-drawn style technical design flowchart, as if sketched on a notebook page.
+Show code file-level and function-level call relationships in a fun, approachable way.
+
+**Topic**: "[topic name]"
+
+### Visual Style Requirements (Cartoon & Sketch Style · Code Granularity)
+
+- Visual aesthetic: hand-drawn cartoon/sketch illustration, playful and approachable
+- Element style: hand-drawn rounded rectangles with wobbly edges, curvy arrow connectors
+- Background: off-white paper texture with subtle grid or dot pattern
+- Color scheme: input layer in pastel yellow; core processing area in pastel blue/lavender;
+  [if sub-paths: primary path pastel green, secondary path pastel pink]; output layer pastel coral/orange
+- Typography: handwriting-style for step titles, handwriting-monospace hybrid for code paths,
+  playful feel throughout
+
+#### Code Granularity Style Rules (Sketch Edition)
+- **Node internal structure**: each node looks like a hand-drawn sticky note or index card;
+  top zone: step name in bold handwriting; bottom zone: code annotation in smaller
+  handwriting-monospace inside a small hand-drawn code block (like a torn piece of paper),
+  format: `📝 file/path → function_name()`
+- **Call relationship arrows**: direct function call = hand-drawn solid curvy arrow;
+  cross-process/CLI/tool call = hand-drawn dashed curvy arrow with small lightning bolt icon,
+  labeled with call method
+- **Arrow labels**: casual handwriting font
+- **Module boundaries**: different languages use different pastel sticky-note backgrounds —
+  TypeScript: pastel blue; Rust: pastel orange; Python: pastel green;
+  Shell/CLI: light gray torn paper; wobbly hand-drawn borders with doodle language icon at top
+
+### Flowchart Structure and Content ([layout direction] layout, all text in [confirmed language])
+
+**[Column 1: Input Layer]**
+[One pastel-yellow hand-drawn node per input source, with lightbulb doodle]
+[Curvy hand-drawn arrows converge to a doodle merge point]
+
+**[Column 2+: Core Processing Area]**
+[Hand-drawn containers with wobbly borders]
+[Sub-regions wrapped in hand-drawn dashed borders]
+[Each sub-node top zone: step name in bold handwriting]
+[Each sub-node bottom zone (smaller, in torn-paper code block):
+  📝 [file path] → [entry function()]
+  📝 [file path 2] → [helper function()] (if multiple files)]
+[Arrows between nodes:
+  - Solid curvy arrow = direct call, labeled in handwriting
+  - Dashed curvy arrow + ⚡ = indirect call, labeled "[call method]: [target function]"]
+[Different language modules on different pastel sticky-note backgrounds]
+[External reference nodes: hand-drawn cloud/folder doodle icons]
+
+**[Last Column: Output Layer]**
+Curvy arrow to pastel coral/orange node with rocket doodle, labeled: "[output name]"
+Inside the node:
+- [Dimension 1]: [value 1] | [value 2] | ...
+- [Dimension 2]: [value A] | [value B] | ...
+
+### Final Check
+Ensure all text is clear and in [confirmed language]; code paths are legible despite playful font;
+hand-drawn style is consistent; solid/dashed arrows are visually distinct; the diagram is
+technically accurate while feeling fun and approachable.
+```
+
 ---
 
 ## Common Mistakes
@@ -303,3 +505,6 @@ Output layer: Applied code patches | Shell command output
 | Reporting granularity contains code details | No file paths, function names, or class names in reporting granularity |
 | Code granularity requested but input has no implementation details | Inform user, fall back to reporting granularity, or ask for a project path |
 | Generated prompt contains absolute paths | All file paths in the generated prompt must be relative (e.g., `src/agent/control.rs`). Never include machine-local absolute paths like `/Users/xxx/...` |
+| Cartoon style used with wrong template | Cartoon & Sketch style must use Template C/D, not Template A/B — the visual language is completely different |
+| Cartoon style too cluttered with doodles | Decorative elements should enhance, not overwhelm — max 1 small icon per node, sparse stars/squiggles |
+| Mixing styles in a single prompt | Never mix NotebookLM and Cartoon & Sketch elements in one prompt — pick one and stay consistent |


### PR DESCRIPTION
## What

Add a second visual style option to the flow-viz-prompt skill: **Cartoon & Sketch Style**, inspired by [angie.temaly.com](https://angie.temaly.com/).

## Why

The current skill only supports NotebookLM style (clean/professional). A hand-drawn, playful style is great for:
- Blog posts and social media
- Making technical diagrams more approachable
- Non-technical audiences
- Fun presentations

## Changes

- **Style detection** (Step 0): Auto-detects style from keywords (cartoon, sketch, hand-drawn, 卡通, 手绘)
- **Cartoon & Sketch Visual Style Spec**: Complete spec including pastel colors, wobbly borders, doodle icons, paper texture background
- **Code granularity support**: Sticky-note style nodes with torn-paper code blocks
- **Template C** (Cartoon & Sketch, Reporting): Full prompt template
- **Template D** (Cartoon & Sketch, Code): Full prompt template with code annotations
- **Common mistakes**: 3 new style-related entries
- **Updated description**: Added cartoon/sketch trigger keywords

## Design Reference

Style inspired by: https://angie.temaly.com/ (cartoon & sketch style)

## Backward Compatible

- Default style remains NotebookLM (no change for existing users)
- Existing Templates A/B unchanged
- Style selection is automatic based on keywords